### PR TITLE
Initial support for calc and other functions

### DIFF
--- a/lib/prop.js
+++ b/lib/prop.js
@@ -1,6 +1,7 @@
 function main(configuration) {
   var config = configuration;
   var util = require('./util.js').configure(config);
+  var list = require('postcss').list;
   var properties =
   [
     {
@@ -27,52 +28,35 @@ function main(configuration) {
     {
       "name": "four-value syntax",
       "expr": /^(margin|padding|border-(color|style|width))$/ig,
-      "match": /[^\s]+/g,
-      "other": /hsl(a?)\(.*?\)|rgb(a?)\(.*?\)/ig,
-      "others": [],
-      "saveOthers": function (value) {
-        var self = this;
-        return value.replace(this.other, function (m) { self.others.push(m); return "temp" + self.others.length });
-      },
-      "restoreOthers": function (value) {
-        var self = this;
-        return value.replace(/temp(\d+)/ig, function (m, i) { return self.others[i - 1]; });
-      },
       "action": function (prop, value) {
-        var newValue = this.saveOthers(value);
-        var result = newValue.split(' ');
-        if (result && result.length == 4 && (this.others.length > 0 || result[1] != result[3])) {
-          var i = 0;
-          newValue = newValue.replace(this.match, function () { return result[(4 - i++) % 4]; });
+        var result = list.space(value);
+        if (result && result.length == 4 && result[1] !== result[3]) {
+          value = [result[0], result[3], result[2], result[1]].join(' ');
         }
-        return { 'prop': prop, 'value': this.restoreOthers(newValue) };
+        return { 'prop': prop, 'value': value };
       }
     },
     {
       "name": "border radius",
       "expr": /border-radius/ig,
-      "match": /(\-?(\d*?\.\d+|\d+))(:?ex|ch|r?em|vh|vw|vmin|vmax|px|mm|cm|in|pt|pc|%)?/ig,
       "flip": function (value) {
-        var parts = value.match(this.match);
-        var i;
+        var parts = list.space(value);
         if (parts)
           switch (parts.length) {
             case 2:
-              i = 1;
               if (parts[0] != parts[1])
-                return value.replace(this.match, function () { return parts[i--]; });
+                return parts[1] + ' ' + parts[0];
               break;
             case 3:
               return parts[1] + ' ' + value;
             case 4:
-              i = 0;
               if (parts[0] != parts[1] || parts[2] != parts[3])
-                return value.replace(this.match, function () { return parts[(5 - i++) % 4]; });
+                return [parts[1], parts[0], parts[3], parts[2]].join(' ');
           }
         return value;
       },
       "action": function (prop, value) {
-        var parts = value.split("/");
+        var parts = list.split(value, ['/']); // TODO: this is an undocumented API. should do a pull request to postcss.
         for (var x = 0; x < parts.length; x++)
           parts[x] = this.flip(parts[x]);
         return { 'prop': prop, 'value': parts.join("/") };
@@ -80,23 +64,27 @@ function main(configuration) {
     },
     {
       "name": "shadow",
-      "expr": /shadow/ig,
-      "replace": /(\-?(\d*?\.\d+|\d+))/i,
-      "other": /hsl(a?)\(.*?\)|rgb(a?)\(.*?\)/ig,
-      "others": [],
-      "saveOthers": function (value) {
-        var self = this;
-        return value.replace(this.other, function (m) { self.others.push(m); return "temp" });
-      },
-      "restoreOthers": function (value) {
-        var self = this;
-        return value.replace(/temp/ig, function () { return self.others.shift(); });
-      },
+      "expr": /(:?box|text)-shadow/ig,
+      "firstWord": /^[-a-z#]*/,
       "action": function (prop, value) {
-        var parts = this.saveOthers(value).split(",");
-        for (var x = 0; x < parts.length; x++)
-          parts[x] = util.negate(parts[x]);
-        return { 'prop': prop, 'value': this.restoreOthers(parts.join(",")) };
+        var parts = list.comma(value);
+        for (var x = 0; x < parts.length; x++) {
+          var subparts = list.space(parts[x]);
+          if (subparts.length > 1) {
+            var firstword = this.firstWord.exec(subparts[0])[0];
+
+            // box-shadow might have the keyword 'inset' in first position
+            // text-shadow might have a color in first position
+            var leftposition = firstword.indexOf('inset') !== -1 || firstword[0] === '#' || firstword.indexOf('rgb') !== -1 || firstword.indexOf('hsl') !== -1 || firstword.length === subparts[0].length ? 1 : 0;
+
+            // util.negate doesn't handle calc yet
+            if (subparts[leftposition].indexOf('calc') === -1) {
+              subparts[leftposition] = util.negate(subparts[leftposition]);
+              parts[x] = subparts.join(' ');
+            }
+          }
+        }
+        return { 'prop': prop, 'value': parts.join(",") };
       }
     },
     {
@@ -180,7 +168,7 @@ function main(configuration) {
       "name": "transition",
       "expr": /transition(-property)?$/i,
       "action": function (prop, value) {
-        var parts = value.split(/,(?![^\)]*?\))/ig);
+        var parts = list.comma(value);
         for (var x = 0; x < parts.length; x++)
           parts[x] = util.swapLeftRight(parts[x]);
         return { 'prop': prop, 'value': parts.join(',') };

--- a/test/test.js
+++ b/test/test.js
@@ -247,8 +247,8 @@ var tests = {
       },
       {
         'should': 'Should mirror property value: transition',
-        'expected': '.foo { transition: right .3s ease .1s, left .3s ease .1s, margin-right .3s ease, margin-left .3s ease, padding-right .3s ease, padding-left .3s ease}',
-        'input': '.foo { transition: left .3s ease .1s, right .3s ease .1s, margin-left .3s ease, margin-right .3s ease, padding-left .3s ease, padding-right .3s ease}',
+        'expected': '.foo { transition: right .3s ease .1s,left .3s ease .1s,margin-right .3s ease,margin-left .3s ease,padding-right .3s ease,padding-left .3s ease}',
+        'input': '.foo { transition: left .3s ease .1s,right .3s ease .1s,margin-left .3s ease,margin-right .3s ease,padding-left .3s ease,padding-right .3s ease}',
         'reversable': true
       },
       {
@@ -261,8 +261,8 @@ var tests = {
   'Mirrored Values (N Value Syntax):': [
        {
          'should': 'Should mirror property value: border-radius (4 values)',
-         'expected': 'div { border-radius: 40.25px 10.5px 10.75px 40.3px; }',
-         'input': 'div { border-radius: 10.5px 40.25px 40.3px 10.75px; }',
+         'expected': 'div { border-radius: 40.25px calc(10.5px / 2) 10.75px 40.3px; }',
+         'input': 'div { border-radius: calc(10.5px / 2) 40.25px 40.3px 10.75px; }',
          'reversable': true
        },
        {
@@ -279,20 +279,20 @@ var tests = {
        },
        {
          'should': 'Should mirror property value: border-radius (4 values - double)',
-         'expected': 'div { border-radius: 40.25px 10.75px .5px 40.75px / .4em 1em 1em 4.5em; }',
-         'input': 'div { border-radius: 10.75px 40.25px 40.75px .5px / 1em .4em 4.5em 1em; }',
+         'expected': 'div { border-radius: 40.25px 10.75px .5px 40.75px/.4em 1em 1em 4.5em; }',
+         'input': 'div { border-radius: 10.75px 40.25px 40.75px .5px/1em .4em 4.5em 1em; }',
          'reversable': true
        },
        {
          'should': 'Should mirror property value: border-radius (3 values - double)',
-         'expected': 'div { border-radius: .40px 10.5px .40px 40px /4em  1em 4em 3em; }',
+         'expected': 'div { border-radius: .40px 10.5px .40px 40px/4em 1em 4em 3em; }',
          'input': 'div { border-radius: 10.5px .40px 40px / 1em 4em 3em; }',
          'reversable': false
        },
        {
          'should': 'Should mirror property value: border-radius (2 values- double)',
-         'expected': 'div { border-radius: 40px 10px / 2.5em .75em; }',
-         'input': 'div { border-radius: 10px 40px / .75em 2.5em; }',
+         'expected': 'div { border-radius: calc(40px / 2) 10px/2.5em .75em; }',
+         'input': 'div { border-radius: 10px calc(40px / 2)/.75em 2.5em; }',
          'reversable': true
        },
        {
@@ -344,21 +344,39 @@ var tests = {
          'reversable': true
        },
        {
+         'should': 'Should mirror property value: padding with functions',
+         'expected': 'div { padding: calc((1px + 3%) * 2) -ms-calc((((((((((((((((4px)))))))))))))))) -moz-calc(7*.3rem) -webkit-calc((2.5em - 1%) / 2); }',
+         'input': 'div { padding: calc((1px + 3%) * 2) -webkit-calc((2.5em - 1%) / 2) -moz-calc(7*.3rem) -ms-calc((((((((((((((((4px)))))))))))))))); }',
+         'reversable': true
+       },
+       {
          'should': 'Should mirror property value: box-shadow',
-         'expected': 'div { box-shadow: -60px -16px rgba(0, 128, 128, 0.98), -10.25px 5px 5px #ff0, inset -0.5em 1em 0 white; }',
-         'input': 'div { box-shadow: 60px -16px rgba(0, 128, 128, 0.98), 10.25px 5px 5px #ff0, inset 0.5em 1em 0 white; }',
+         'expected': 'div { box-shadow: -60px -16px rgba(0, 128, 128, 0.98),-10.25px 5px 5px #ff0,inset -0.5em 1em 0 white; }',
+         'input': 'div { box-shadow: 60px -16px rgba(0, 128, 128, 0.98),10.25px 5px 5px #ff0,inset 0.5em 1em 0 white; }',
          'reversable': true
        },
        {
          'should': 'Should mirror property value: text-shadow',
-         'expected': 'div { text-shadow: -60px -16px rgba(0, 128, 128, 0.98), -10.25px 5px 5px #ff0, inset -0.5em 1em 0 white; }',
-         'input': 'div { text-shadow: 60px -16px rgba(0, 128, 128, 0.98), 10.25px 5px 5px #ff0, inset 0.5em 1em 0 white; }',
+         'expected': 'div { text-shadow: -60px -16px rgba(127, 128, 129, 0.98),-10.25px 5px 5px #ff8,-0.5em 1em 0 white; }',
+         'input': 'div { text-shadow: 60px -16px rgba(127, 128, 129, 0.98),10.25px 5px 5px #ff8,0.5em 1em 0 white; }',
+         'reversable': true
+       },
+       {
+         'should': 'Should mirror property value: text-shadow (color in front)',
+         'expected': 'div { text-shadow: rgba(127, 128, 129, 0.98) -60px -16px,#ff8 -10.25px 5px 5px,white -0.5em 1em 0; }',
+         'input': 'div { text-shadow: rgba(127, 128, 129, 0.98) 60px -16px,#ff8 10.25px 5px 5px,white 0.5em 1em 0; }',
          'reversable': true
        },
        {
          'should': 'Should mirror property value (no digit before the dot): box-shadow, text-shadow',
-         'expected': 'div { box-shadow: inset -0.5em 1em 0 white; text-shadow: inset -0.5em 1em 0 white; }',
-         'input': 'div { box-shadow: inset .5em 1em 0 white; text-shadow: inset .5em 1em 0 white; }',
+         'expected': 'div { box-shadow: inset -0.5em 1em 0 white; text-shadow: -0.5em 1em 0 white; }',
+         'input': 'div { box-shadow: inset .5em 1em 0 white; text-shadow: .5em 1em 0 white; }',
+         'reversable': false
+       },
+       {
+         'should': 'Should no touch special values: box-shadow, text-shadow',
+         'expected': 'div { box-shadow: none; text-shadow: inherit; }',
+         'input': 'div { box-shadow: none; text-shadow: inherit; }',
          'reversable': false
        }
   ],


### PR DESCRIPTION
Proper parsing of list based properties. It is now possible to reverse this expression

```
border-radius: 40.25px calc(10.5px / 2) 10.75px 40.3px;
```

I also fixed the handling of [text-shadow](https://developer.mozilla.org/en-US/docs/Web/CSS/text-shadow). Previous code was transforming `#ff8 10.25px 5px 5px` into `#ff-8 10.25px 5px 5px`.

Note that the output is slightly more compressed than before. I hope it is not an issue as I expect most user to be using minification and sourcemaps anyway.