### PR TITLE
Add useCalc flag

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -21,6 +21,7 @@ function main (opts, plugins, hooks) {
   addKey('greedy', false)
   addKey('processUrls', false)
   addKey('stringMap', [])
+  addKey('useCalc', false)
 
   // default strings map
   if (Array.isArray(config.stringMap)) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -415,11 +415,20 @@ module.exports = {
               ? '100%'
               : (parts[0].match(this.cache.percent)
                 ? context.util.complement(parts[0])
-                : context.util.swapLeftRight(parts[0]))
+                : (parts[0].match(this.cache.length)
+                  ? this.flipLength(parts[0], context)
+                  : context.util.swapLeftRight(parts[0])))
             state.value = state.value.replace(this.cache.match, function () { return parts.shift() })
           }
         }
         return util.restoreTokens(state)
+      },
+      'flipLength': function (value, context) {
+        if (context.config.useCalc) {
+          return 'calc(100% - ' + value + ')'
+        }
+
+        return context.util.swapLeftRight(value)
       },
       'update': function (context, value, name) {
         if (name.match(this.cache.gradient)) {
@@ -438,6 +447,7 @@ module.exports = {
             'match': context.util.regex(['position', 'percent', 'length', 'calc'], 'ig'),
             'percent': context.util.regex(['calc', 'percent'], 'i'),
             'position': context.util.regex(['position'], 'g'),
+            'length': context.util.regex(['length'], 'gi'),
             'gradient': /gradient$/i,
             'angle': /\d+(deg|g?rad|turn)/i,
             'url': /^url/i

--- a/test/data/rtlcss-options.js
+++ b/test/data/rtlcss-options.js
@@ -119,5 +119,12 @@ module.exports = [
     'expected': 'div { border-radius: 40.25px 10.5px /*comment*/ 10.75px 40.3px; }',
     'input': 'div { border-radius: 10.5px 40.25px /*comment*/ 40.3px 10.75px; }',
     'reversable': true
+  },
+  {
+    'should': 'Should flip background-position when expressed in units',
+    'expected': 'div { background-position: calc(100% - 10px) 0 }',
+    'input': 'div { background-position: 10px 0 }',
+    'reversable': false,
+    'options': { 'useCalc': true }
   }
 ]


### PR DESCRIPTION
Following up on our conversation on gitter this is a pull request to enable RTLCSS to use calc when flipping background-position(-x) specified in units 

E.g.`background-position: 10px 0` becomes `background-position: calc(100% - 10px) 0`

Tested with `npm test`