### PR TITLE
Should mirror keyword horizontal position (with value)

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -406,9 +406,10 @@ module.exports = {
       'flip': function (value, context, isPosition) {
         var state = util.saveTokens(value, true)
         var parts = state.value.match(this.cache.match)
+
         if (parts && parts.length > 0) {
           var keywords = (state.value.match(this.cache.position) || '').length
-          if (isPosition && (/* edge offsets */ parts.length >= 3 || /* keywords only */ keywords === 2)) {
+          if (/* edge offsets */ parts.length >= 3 || /* keywords only */ keywords === 2) {
             state.value = util.swapLeftRight(state.value)
           } else {
             parts[0] = parts[0] === '0'

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -403,7 +403,7 @@ module.exports = {
       'name': 'background',
       'expr': /background(-position(-x)?|-image)?$/i,
       'cache': null,
-      'flip': function (value, context, isPosition) {
+      'flip': function (value, context) {
         var state = util.saveTokens(value, true)
         var parts = state.value.match(this.cache.match)
 
@@ -459,9 +459,8 @@ module.exports = {
         var parts = funcSafe.value.split(',')
         var lprop = prop.toLowerCase()
         if (lprop !== 'background-image') {
-          var isPosition = lprop === 'background-position'
           for (var x = 0; x < parts.length; x++) {
-            parts[x] = this.flip(parts[x], context, isPosition)
+            parts[x] = this.flip(parts[x], context)
           }
         }
         funcSafe.value = parts.join(',')

--- a/test/data/background.js
+++ b/test/data/background.js
@@ -24,6 +24,12 @@ module.exports = [
     'reversable': true
   },
   {
+    'should': 'Should mirror keyword horizontal position (with value)',
+    'expected': '.banner { background: #00D url(topbanner.png) no-repeat top 50% left 16px; }',
+    'input': '.banner { background: #00D url(topbanner.png) no-repeat top 50% right 16px; }',
+    'reversable': true
+  },
+  {
     'should': 'Should not process string map in url (default)',
     'expected': '.banner { background: 10px top url(ltr-top-right-banner.png) #00D repeat-y fixed; }',
     'input': '.banner { background: 10px top url(ltr-top-right-banner.png) #00D repeat-y fixed; }',

--- a/test/test.js
+++ b/test/test.js
@@ -33,7 +33,7 @@ for (key in tests) {
       })(item)
       if (item.reversable) {
         (function (test) {
-          it(test.should + ' <REVERESE>', function (done) {
+          it(test.should + ' <REVERSED>', function (done) {
             assert.equal(rtlcss.process(test.expected, test.options, test.plugins, test.hooks), test.input)
             done()
           })


### PR DESCRIPTION
I noticed that for `background: #00D url(topbanner.png) no-repeat top 50% right 16px` the positioning offsets don't get flipped. I wasn't sure why you had a isPosition check, but it looks that without it the bug is fixed and all the tests pass.