### PR TITLE
Don't use calc to flip 0px

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -412,13 +412,16 @@ module.exports = {
           if (/* edge offsets */ parts.length >= 3 || /* keywords only */ keywords === 2) {
             state.value = util.swapLeftRight(state.value)
           } else {
-            parts[0] = parts[0] === '0'
-              ? '100%'
-              : (parts[0].match(this.cache.percent)
-                ? context.util.complement(parts[0])
-                : (parts[0].match(this.cache.length)
-                  ? this.flipLength(parts[0], context)
-                  : context.util.swapLeftRight(parts[0])))
+            if (parts[0] === '0') {
+              parts[0] = '100%'
+            } else if (parts[0].match(this.cache.percent)) {
+              parts[0] = context.util.complement(parts[0])
+            } else if (parts[0].match(this.cache.length)) {
+              parts[0] = this.flipLength(parts[0], context)
+            } else {
+              parts[0] = context.util.swapLeftRight(parts[0])
+            }
+
             state.value = state.value.replace(this.cache.match, function () { return parts.shift() })
           }
         }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -426,6 +426,10 @@ module.exports = {
       },
       'flipLength': function (value, context) {
         if (context.config.useCalc) {
+          var rootValue = Number(value.replace(/[^-\d\.]/g, ''))
+          if (!rootValue) {
+            return '100%'
+          }
           return 'calc(100% - ' + value + ')'
         }
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -406,9 +406,10 @@ module.exports = {
       'flip': function (value, context, isPosition) {
         var state = util.saveTokens(value, true)
         var parts = state.value.match(this.cache.match)
+
         if (parts && parts.length > 0) {
           var keywords = (state.value.match(this.cache.position) || '').length
-          if (isPosition && (/* edge offsets */ parts.length >= 3 || /* keywords only */ keywords === 2)) {
+          if (/* edge offsets */ parts.length >= 3 || /* keywords only */ keywords === 2) {
             state.value = util.swapLeftRight(state.value)
           } else {
             parts[0] = parts[0] === '0'

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -403,7 +403,7 @@ module.exports = {
       'name': 'background',
       'expr': /background(-position(-x)?|-image)?$/i,
       'cache': null,
-      'flip': function (value, context, isPosition) {
+      'flip': function (value, context) {
         var state = util.saveTokens(value, true)
         var parts = state.value.match(this.cache.match)
 
@@ -459,9 +459,8 @@ module.exports = {
         var parts = funcSafe.value.split(',')
         var lprop = prop.toLowerCase()
         if (lprop !== 'background-image') {
-          var isPosition = lprop === 'background-position'
           for (var x = 0; x < parts.length; x++) {
-            parts[x] = this.flip(parts[x], context, isPosition)
+            parts[x] = this.flip(parts[x], context)
           }
         }
         funcSafe.value = parts.join(',')

--- a/test/data/background.js
+++ b/test/data/background.js
@@ -24,6 +24,12 @@ module.exports = [
     'reversable': true
   },
   {
+    'should': 'Should mirror keyword horizontal position (with value)',
+    'expected': '.banner { background: #00D url(topbanner.png) no-repeat top 50% left 16px; }',
+    'input': '.banner { background: #00D url(topbanner.png) no-repeat top 50% right 16px; }',
+    'reversable': true
+  },
+  {
     'should': 'Should not process string map in url (default)',
     'expected': '.banner { background: 10px top url(ltr-top-right-banner.png) #00D repeat-y fixed; }',
     'input': '.banner { background: 10px top url(ltr-top-right-banner.png) #00D repeat-y fixed; }',

--- a/test/data/rtlcss-options.js
+++ b/test/data/rtlcss-options.js
@@ -126,5 +126,12 @@ module.exports = [
     'input': 'div { background-position: 10px 0 }',
     'reversable': false,
     'options': { 'useCalc': true }
+  },
+  {
+    'should': 'Should flip background-position when expressed in units (0px should be flipped without calc)',
+    'expected': 'div { background-position: 100% 0 }',
+    'input': 'div { background-position: 0px 0 }',
+    'reversable': false,
+    'options': { 'useCalc': true }
   }
 ]

--- a/test/test.js
+++ b/test/test.js
@@ -33,7 +33,7 @@ for (key in tests) {
       })(item)
       if (item.reversable) {
         (function (test) {
-          it(test.should + ' <REVERESE>', function (done) {
+          it(test.should + ' <REVERSED>', function (done) {
             assert.equal(rtlcss.process(test.expected, test.options, test.plugins, test.hooks), test.input)
             done()
           })


### PR DESCRIPTION
No need to flip `0px` (or any other unit) to `calc(100% - 0px)`, so I'm just going to go for `100%` directly.

I also think we're using the ternary operator too much, so I rewrote it a bit, to make it easier to read and debug that piece of code,.

Not sure why github is showing 5 commits, since 3 of them are already merged... if this is a problem let me know and I'll try to figure out a solution.