### PR TITLE
CLI: replace sys.print with process.stdout.write

### DIFF
--- a/bin/rtlcss.js
+++ b/bin/rtlcss.js
@@ -2,7 +2,6 @@
 
 var path = require('path')
 var fs = require('fs')
-var sys = require('util')
 var chalk = require('chalk')
 var mkdirp = require('mkdirp')
 var postcss = require('postcss')
@@ -169,7 +168,7 @@ if (!shouldBreak) {
         fs.writeFile(savePath + '.map', result.map, 'utf8', function (err) { err && printError(err) })
       }
     } else {
-      sys.print(result.css)
+      process.stdout.write(result.css)
     }
   }
 


### PR DESCRIPTION
In recent versions of `node`, `util.print` doesn't actually output anything (see deprecated status [here](https://node.readthedocs.io/en/latest/api/util/#utilprint)), so this switches to `process.stdout.write` which seems to be the common way to output to stdout without formatting.

Note: tested on node v12.13.1

Fixes #156 