### PR TITLE
Update mkdirp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "chalk": "^2.4.2",
     "findup": "^0.1.5",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^1.0.3",
     "postcss": "^6.0.23",
     "strip-json-comments": "^2.0.0"
   },


### PR DESCRIPTION
`mkdirp@0.5.1`, uses package `minimist` that had Prototype pollution bug in versions previous to v1.2.3: https://www.npmjs.com/advisories/1179.
The new version of mkdirp no longer do so. (update from `0.x.x` to `1.x.x`)