### PR TITLE
[CLI] Empty output when --silent and --stdin flags are used together

### DIFF
--- a/bin/rtlcss.js
+++ b/bin/rtlcss.js
@@ -168,7 +168,7 @@ if (!shouldBreak) {
         fs.writeFile(savePath + '.map', result.map, 'utf8', function (err) { err && printError(err) })
       }
     } else {
-      console.log(result.css)
+      process.stdout.write(result.css + '\n')
     }
   }
 


### PR DESCRIPTION
When rtlcss is called with both --silent and --stdin to take the css
from stdin and output to stdout, the --silent flag results in no output
since console.log is redefined to be an empty function. Using
process.stdout.write instead of console.log fixes this issue.

Fixes https://github.com/MohammadYounes/rtlcss/issues/169