### PR TITLE
deps - remove String.prototype polluting "colors" deep dep

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -2,7 +2,7 @@
 'use strict'
 var fs = require('fs')
 var path = require('path')
-var findup = require('findup')
+var findup = require('@choojs/findup')
 var stripJSONComments = require('strip-json-comments')
 var config = {}
 var configSources = ['package.json', '.rtlcssrc', '.rtlcss.json']

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@choojs/findup": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
+      "integrity": "sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==",
+      "requires": {
+        "commander": "^2.15.1"
+      }
+    },
     "acorn": {
       "version": "5.7.4",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
@@ -177,16 +185,10 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
-    "colors": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
-    },
     "commander": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-      "dev": true
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -615,22 +617,6 @@
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
       "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "dev": true
-    },
-    "findup": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
-      "integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
-      "requires": {
-        "colors": "~0.6.0-1",
-        "commander": "~2.1.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-          "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E="
-        }
-      }
     },
     "flat-cache": {
       "version": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "rtlcss": "./bin/rtlcss.js"
   },
   "dependencies": {
+    "@choojs/findup": "^0.2.1",
     "chalk": "^2.4.2",
-    "findup": "^0.1.5",
     "mkdirp": "^0.5.1",
     "postcss": "^6.0.23",
     "strip-json-comments": "^2.0.0"


### PR DESCRIPTION
dependency `colors` (`rtlcss > findup > colors`) is mutating `String.prototype`

`@choojs/findup` includes a patch for this https://github.com/choojs/findup