### PR TITLE
util: remove useless conditional

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -240,7 +240,7 @@ module.exports = {
     let isLast = true
     let next = node.next()
     while (next) {
-      if (next && next.type === node.type) {
+      if (next.type === node.type) {
         isLast = false
         break
       }


### PR DESCRIPTION
Noticed this and #183 with lgtm.com https://lgtm.com/projects/g/MohammadYounes/rtlcss?mode=list

There is one issue left to sort:

>Properties are copied from `from` to `to` without guarding against prototype pollution.

https://github.com/MohammadYounes/rtlcss/blob/cd0e5cd3b362a6fd883664576a011f2c0a65dbb5/lib/config-loader.js#L76