### PR TITLE
CI: Add Node.js 15.x too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12, 14]
+        node: [10, 12, 14, 15]
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
Better be sure everything runs smoothly on the upcoming Node.js release. Note that when 16.x is out, you should replace 15 with 16 :)