### PR TITLE
Revert "config-loader.js guard for in loop"

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -70,12 +70,10 @@ function loadConfig (dir) {
 function override (to, from) {
   if (to && from) {
     for (const p in from) {
-      if (Object.prototype.hasOwnProperty.call(from, p)) {
-        if (typeof to[p] === 'object') {
-          override(to[p], from[p])
-        } else {
-          to[p] = from[p]
-        }
+      if (typeof to[p] === 'object') {
+        override(to[p], from[p])
+      } else {
+        to[p] = from[p]
       }
     }
   }


### PR DESCRIPTION
This reverts commit dfa4a3282d316dd9607b9a42b358144e4cc8cd31.

I did this quickly and I don't think it's the proper fix. Let's revert this until we have a proper fix