### PR TITLE
Add aliases option

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -22,6 +22,7 @@ function main (opts, plugins, hooks) {
   addKey('processUrls', false)
   addKey('stringMap', [])
   addKey('useCalc', false)
+  addKey('aliases', {})
 
   // default strings map
   if (Array.isArray(config.stringMap)) {

--- a/lib/rtlcss.js
+++ b/lib/rtlcss.js
@@ -143,13 +143,14 @@ module.exports = function (options, plugins, hooks) {
         // loop over all plugins/property processors
         context.util.each(context.config.plugins, function (plugin) {
           return context.util.each(plugin.processors, function (processor) {
-            if (node.prop.match(processor.expr)) {
+            const alias = context.config.aliases[node.prop]
+            if ((alias || node.prop).match(processor.expr)) {
               const raw = node.raws.value && node.raws.value.raw ? node.raws.value.raw : node.value
               const state = context.util.saveComments(raw)
               const pair = processor.action(node.prop, state.value, context)
               state.value = pair.value
               pair.value = context.util.restoreComments(state)
-              if (pair.prop !== node.prop || pair.value !== raw) {
+              if ((!alias && pair.prop !== node.prop) || pair.value !== raw) {
                 flipped++
                 node.prop = pair.prop
                 node.value = pair.value

--- a/test/data/variables.js
+++ b/test/data/variables.js
@@ -11,5 +11,26 @@ module.exports = [
     expected: ':root {--brightest: red}',
     input: ':root {--brightest: red}',
     reversable: true
+  },
+  {
+    should: 'Should flip variable values if it is flagged as an alias',
+    expected: ':root {--pad: 10px 4px 2px 5px}',
+    input: ':root {--pad: 10px 5px 2px 4px}',
+    reversable: true,
+    options: { aliases: { '--pad': 'padding' } }
+  },
+  {
+    should: 'Should not flip variable names starting with direction included in aliases',
+    expected: ':root {--left-margin: 10px}',
+    input: ':root {--left-margin: 10px}',
+    reversable: true,
+    options: { aliases: { '--left-margin': 'left' } }
+  },
+  {
+    should: 'Should not flip variable names containing direction included in aliases',
+    expected: ':root {--brightest: 10px}',
+    input: ':root {--brightest: 10px}',
+    reversable: true,
+    options: { aliases: { '--brightest': 'right' } }
   }
 ]


### PR DESCRIPTION
In this moment, if a variable contains a value that should be flipped in RTL, it is ignored, for example:

### input

```css
:root {
    --small-padding: 2px 5px 2px 10px;
}

.rule {
    padding: var(--small-padding);
}
```

### output

```css
:root {
    --small-padding: 2px 5px 2px 10px;
}

.rule {
    padding: var(--small-padding);
}
```

The purpose of this pull request is to create a configuration object to hold property-name aliases and in this way treat the values of those properties as the values of others:

### input

```css
/*rtl:options:
{
    "aliases": {
        "--small-padding": "padding"
    }
}*/
:root {
    --small-padding: 2px 5px 2px 10px;
}

.rule {
    padding: var(--small-padding);
}
```

### output

```css
:root {
    --small-padding: 2px 10px 2px 5px;
}

.rule {
    padding: var(--small-padding);
}
```

>