### PR TITLE
Remove mkdirp package

### DIFF
--- a/bin/rtlcss.js
+++ b/bin/rtlcss.js
@@ -3,7 +3,6 @@
 'use strict'
 const path = require('path')
 const fs = require('fs')
-const mkdirp = require('mkdirp')
 const picocolors = require('picocolors')
 const postcss = require('postcss')
 const rtlcss = require('../lib/rtlcss')
@@ -209,7 +208,7 @@ if (!shouldBreak) {
               // create output directory if it does not exist
               const dirName = path.dirname(rtlFile)
               if (!fs.existsSync(dirName)) {
-                mkdirp.sync(dirName)
+                fs.mkdirSync(dirName, { recursive: true })
               }
 
               // read and process the file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1519,11 +1519,6 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
-    "mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-    },
     "mocha": {
       "version": "9.1.3",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "find-up": "^5.0.0",
-    "mkdirp": "^1.0.4",
     "picocolors": "^1.0.0",
     "postcss": "^8.0.0",
     "strip-json-comments": "^3.1.1"


### PR DESCRIPTION
Requires #243.

Works with Node.js >= v10.12.0, but since you don't specify an engines version in package.json I guess we are OK?