### PR TITLE
Replace chalk with picocolors

### DIFF
--- a/bin/rtlcss.js
+++ b/bin/rtlcss.js
@@ -3,8 +3,8 @@
 'use strict'
 const path = require('path')
 const fs = require('fs')
-const chalk = require('chalk')
 const mkdirp = require('mkdirp')
+const picocolors = require('picocolors')
 const postcss = require('postcss')
 const rtlcss = require('../lib/rtlcss')
 const configLoader = require('../lib/config-loader')
@@ -17,15 +17,15 @@ let shouldBreak = false
 process.on('exit', function () { process.reallyExit(currentErrorcode) })
 
 function printWarning (...args) {
-  console.warn(chalk.yellow(...args))
+  console.warn(picocolors.yellow(...args))
 }
 
 function printInfo (...args) {
-  console.info(chalk.green(...args))
+  console.info(picocolors.green(...args))
 }
 
 function printError (...args) {
-  console.error(chalk.red(...args))
+  console.error(picocolors.red(...args))
 }
 
 function printHelp () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -179,6 +179,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -303,6 +304,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -339,6 +341,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -346,7 +349,8 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1132,7 +1136,8 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -2376,6 +2381,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "rtlcss": "./bin/rtlcss.js"
   },
   "dependencies": {
-    "chalk": "^4.1.2",
     "find-up": "^5.0.0",
     "mkdirp": "^1.0.4",
-    "postcss": "^8.3.11",
+    "picocolors": "^1.0.0",
+    "postcss": "^8.0.0",
     "strip-json-comments": "^3.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
picocolors is used by postcss itself too so it'll be in the deps tree:

```
C:\Users\xmr\Desktop\rtlcss>npm ls picocolors
rtlcss@3.4.0 C:\Users\xmr\Desktop\rtlcss
+-- picocolors@1.0.0
`-- postcss@8.3.11
  `-- picocolors@1.0.0  deduped
```

If there are any conflicts ping me to rebase :)