### PR TITLE
package.json fix postcss dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,15 +30,12 @@
   "dependencies": {
     "find-up": "^5.0.0",
     "picocolors": "^1.0.0",
-    "postcss": "^8.0.0",
+    "postcss": "^8.3.11",
     "strip-json-comments": "^3.1.1"
   },
   "devDependencies": {
     "mocha": "^9.1.3",
     "standard": "^16.0.4"
-  },
-  "peerDependencies": {
-    "postcss": "^8.0.0"
   },
   "scripts": {
     "main": "node ./lib/rtlcss.js",


### PR DESCRIPTION
If `postcss` is listed in `dependencies` then it's moot to list it in `peerDependencies` too since package managers will always install it.