### PR TITLE
CI: split lint to a separate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
         run: npm ci
 
       - name: Test
-        run: npm test
+        run: npm run test:ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: Lint
+
+on:
+  push:
+    branches-ignore:
+      - "dependabot/**"
+  pull_request:
+
+env:
+  FORCE_COLOR: 2
+  NODE: 16
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "${{ env.NODE }}"
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "lint:fix": "npm run lint -- --fix",
     "mocha": "mocha -R spec",
     "mocha:special": "npm run mocha -- --fgrep \"# Special\"",
-    "test": "npm run lint && npm run main && npm run mocha"
+    "test": "npm run lint && npm run main && npm run mocha",
+    "test:ci": "npm run main && npm run mocha"
   },
   "main": "./lib/rtlcss.js",
   "files": [


### PR DESCRIPTION
Now it'll run once plus you will be able to restart the workflows separately. If GitHub implements this at some point, you can combine the two workflow files.