### PR TITLE
Enforce LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-bin/rtlcss.js text eol=lf
-test/css/*.css css eol=lf
+# Enforce Unix newlines
+* text=auto eol=lf


### PR DESCRIPTION
Requires git >= 2.10 but it's been out for so long that I think it's safe to do this; enforce LF in all files, not only JS files.