### PR TITLE
utils: remove always true parameter

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -160,60 +160,44 @@ module.exports = {
   restoreTokens (state) {
     return this.restore(state)
   },
-  guard (what, who, indexed) {
+  guard (what, who) {
     const state = {
       value: who,
       store: [],
       offset: tokenId++,
-      token: CHAR_TOKEN_START + tokenId,
-      indexed: indexed === true
+      token: CHAR_TOKEN_START + tokenId
     }
-    if (state.indexed === true) {
-      while (what.test(state.value)) {
-        state.value = state.value.replace(what, (m) => {
-          state.store.push(m)
-          return `${state.token}:${state.store.length}${CHAR_TOKEN_END}`
-        })
-      }
-    } else {
+
+    while (what.test(state.value)) {
       state.value = state.value.replace(what, (m) => {
         state.store.push(m)
-        return state.token + CHAR_TOKEN_END
+        return `${state.token}:${state.store.length}${CHAR_TOKEN_END}`
       })
     }
 
     return state
   },
   unguard (state, callback) {
-    if (state.indexed === true) {
-      const detokenizer = new RegExp('(\\w*?)' + state.token + ':(\\d+)' + CHAR_TOKEN_END, 'i')
-      while (detokenizer.test(state.value)) {
-        state.value = state.value.replace(detokenizer, (match, name, index) => {
-          const value = state.store[index - 1]
-          return typeof callback === 'function'
-            ? name + callback(value, name)
-            : name + value
-        })
-      }
-
-      return state.value
+    const detokenizer = new RegExp('(\\w*?)' + state.token + ':(\\d+)' + CHAR_TOKEN_END, 'i')
+    while (detokenizer.test(state.value)) {
+      state.value = state.value.replace(detokenizer, (match, name, index) => {
+        const value = state.store[index - 1]
+        return typeof callback === 'function'
+          ? name + callback(value, name)
+          : name + value
+      })
     }
 
-    return state.value.replace(new RegExp('(\\w*?)' + state.token + CHAR_TOKEN_END, 'i'), (match, name) => {
-      const value = state.store.shift()
-      return typeof callback === 'function'
-        ? name + callback(value, name)
-        : name + value
-    })
+    return state.value
   },
   guardHexColors (value) {
-    return this.guard(REGEX_HEX_COLOR, value, true)
+    return this.guard(REGEX_HEX_COLOR, value)
   },
   unguardHexColors (state, callback) {
     return this.unguard(state, callback)
   },
   guardFunctions (value) {
-    return this.guard(REGEX_FUNCTION, value, true)
+    return this.guard(REGEX_FUNCTION, value)
   },
   unguardFunctions (state, callback) {
     return this.unguard(state, callback)


### PR DESCRIPTION
These are internal functions AFAICT and the `indexed` parameter is always true. Not sure if there's something else I might be missing; if so let me know :)

Non-whitespace diff: https://github.com/MohammadYounes/rtlcss/pull/270/files?w=1