### PR TITLE
config-loader.js: return early

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -52,24 +52,17 @@ function readConfig (configFilePath) {
 
 function loadConfig (cwd) {
   for (const source of configSources) {
-    let foundPath
+    const foundPath = findUp.sync(source, { cwd })
+    if (!foundPath) continue
 
-    try {
-      foundPath = findUp.sync(source, { cwd })
-    } catch (e) {
-      continue
+    config = readConfig(foundPath)
+
+    if (source === 'package.json') {
+      config = config.rtlcssConfig
     }
 
-    if (foundPath) {
-      config = readConfig(foundPath)
-
-      if (source === 'package.json') {
-        config = config.rtlcssConfig
-      }
-
-      if (config) {
-        return config
-      }
+    if (config) {
+      return config
     }
   }
 }


### PR DESCRIPTION
AFAICT `find-up` returns undefined if it didn't find anything, otherwise the path. So, the `try`/`catch` seems redundant?